### PR TITLE
Replace the created artifact with the one with dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
+                    <appendAssemblyId>false</appendAssemblyId>
                     <archive>
                         <manifest>
                             <mainClass>${start-class}</mainClass>


### PR DESCRIPTION
Currently, the `mvn package` generates `kafka-benchmark-1.4.2.jar` which doesn't have a mainClass manifest attribute set. Therefore, if you try to run it with `java -jar kafka-benchmark-1.4.2.jar`, you'll get 
```
no main manifest attribute, in target/kafka-benchmark-1.4.2.jar
```

It also generates a second artifact named `kafka-benchmark-1.4.2-jar-with-dependencies.jar` which is has correctly adjusted manifest file, therefore it should be used instead (in contrast to the documentation). This seems to me confusing and I don't see a usage for the JAR without manifest file properly configured.

This PR basically replaces the default generated JAR with the with-dependencies one. Therefore, you can directly run the benchmark with `java -jar kafka-benchmark-1.4.2.jar` or `java -jar kafka-benchmark-*` as stated in the README.